### PR TITLE
Fix ImageMagick compat + xargs batch tolerance in update-tokens

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -2,8 +2,13 @@
 
 # check if required tools are installed
 command -v rsvg-convert >/dev/null || { echo "rsvg-convert is required"; exit 1; }
-command -v magick >/dev/null || { echo "ImageMagick (magick) is required"; exit 1; }
 command -v cwebp >/dev/null || { echo "cwebp is required"; exit 1; }
+
+# Prefer ImageMagick 7's `magick`, fall back to IM6's `convert`. Both implement
+# the same operators our scripts use; the indirection avoids IM7's deprecation
+# warning that fires on every `convert` invocation.
+MAGICK=$(command -v magick 2>/dev/null || command -v convert)
+[ -n "$MAGICK" ] || { echo "ImageMagick is required (install via brew or apt)"; exit 1; }
 
 # Default size for the images
 SIZE=128
@@ -112,7 +117,7 @@ convert_files() {
             # Omit conversion if resized PNG file already exists
             if [ ! -f "$output_dir_png/$subdir/$filename.png" ]; then
                 # Resize PNG
-                magick "$png_file" -resize "${SIZE}x${SIZE}" "$output_dir_png/$subdir/$filename.png"
+                "$MAGICK" "$png_file" -resize "${SIZE}x${SIZE}" "$output_dir_png/$subdir/$filename.png"
                 if [ $? -eq 0 ]; then
                     print_color_message "Resized $png_file to $output_dir_png/$subdir/$filename.png" "$GREEN"
                 else

--- a/scripts/smoke-test/tests/08-corrupt-webp-tolerance.sh
+++ b/scripts/smoke-test/tests/08-corrupt-webp-tolerance.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verifies that a single malformed webp does not abort convert-webp-to-png.sh
+# under `set -e` + `xargs -P`. Plants a synthetic corrupt webp alongside a
+# real one (INTEGRATION_TARGET, whose color entry is deleted so it must be
+# reconverted), then asserts:
+#   1. yarn update-colors exits 0 (the bad input did not propagate failure)
+#   2. INTEGRATION_TARGET's color entry was regenerated (the batch kept going
+#      past the corrupt file and colors.js ran)
+#
+# Regression target: the fix in convert-webp-to-png.sh that runs each xargs
+# worker with `; echo done` instead of `&& echo done` so magick failures stay
+# scoped to that worker.
+
+set -uo pipefail
+source "$(dirname "$0")/../lib.sh"
+require_integration_prereqs
+
+CORRUPT_WEBP="images/migration/webp/zzz-smoke-corrupt-test.webp"
+INTEGRATION_PNG="images/migration/png/$INTEGRATION_BASE.png"
+
+cp scripts/update-tokens/colors.json /tmp/smoke-pre-colors.json
+
+restore() {
+  rm -f "$CORRUPT_WEBP" "images/migration/png/zzz-smoke-corrupt-test.png"
+  cp /tmp/smoke-pre-colors.json scripts/update-tokens/colors.json
+  rm -f /tmp/smoke-pre-colors.json "$INTEGRATION_PNG" /tmp/smoke-update.log
+}
+trap restore EXIT
+
+# Plant a malformed webp (plain text, magick will reject it).
+echo "this is not a webp" > "$CORRUPT_WEBP"
+
+# Force INTEGRATION_TARGET to be reconverted by removing both its color entry
+# and any cached PNG. Without this, convert-webp-to-png.sh would skip it and
+# we would only exercise the corrupt-only path.
+delete_color_entry
+rm -f "$INTEGRATION_PNG"
+
+yarn update-colors >/tmp/smoke-update.log 2>&1 || {
+  echo "yarn update-colors failed — corrupt webp aborted the batch"
+  tail -30 /tmp/smoke-update.log
+  exit 1
+}
+
+color_entry_present || {
+  echo "valid token's color was not regenerated — convert step likely aborted"
+  tail -20 /tmp/smoke-update.log
+  exit 1
+}

--- a/scripts/update-tokens/convert-webp-to-png.sh
+++ b/scripts/update-tokens/convert-webp-to-png.sh
@@ -70,7 +70,13 @@ echo "Converting $total file(s) with $PARALLELISM parallel workers..."
 # lines are safe to feed to xargs. Each worker emits a marker on stdout when
 # it finishes so the progress bar can advance. Use stdin redirect (not -a) for
 # BSD/macOS xargs compatibility.
-xargs -P "$PARALLELISM" -L 1 bash -c '"$MAGICK" "$0[0]" "$1" && echo done' < "$WORK_LIST" | \
+#
+# Each worker uses `; echo done` (not `&& echo done`) so that a single failed
+# conversion does not propagate non-zero exit status up through xargs and
+# abort the entire script under `set -e`. Failed conversions just produce no
+# PNG — colors.js will then fall back to default colors for that token, same
+# as it does for any other extraction error.
+xargs -P "$PARALLELISM" -L 1 bash -c '"$MAGICK" "$0[0]" "$1" 2>/dev/null; echo done' < "$WORK_LIST" | \
   while read -r _; do
     processed_count=$((${processed_count:-0} + 1))
 

--- a/scripts/update-tokens/convert-webp-to-png.sh
+++ b/scripts/update-tokens/convert-webp-to-png.sh
@@ -6,6 +6,11 @@ PNG_FOLDER="images/migration/png"
 COLORS_JSON="scripts/update-tokens/colors.json"
 PARALLELISM=8
 
+# Prefer ImageMagick 7's `magick`, fall back to IM6's `convert`. Both
+# implement the same operators; this avoids IM7's deprecation warning.
+MAGICK=$(command -v magick 2>/dev/null || command -v convert)
+export MAGICK
+
 # Ensure the source folder exists
 if [ ! -d "$WEBP_FOLDER" ]; then
   echo "Error: Source folder '$WEBP_FOLDER' does not exist."
@@ -65,7 +70,7 @@ echo "Converting $total file(s) with $PARALLELISM parallel workers..."
 # lines are safe to feed to xargs. Each worker emits a marker on stdout when
 # it finishes so the progress bar can advance. Use stdin redirect (not -a) for
 # BSD/macOS xargs compatibility.
-xargs -P "$PARALLELISM" -L 1 bash -c 'magick "$0[0]" "$1" && echo done' < "$WORK_LIST" | \
+xargs -P "$PARALLELISM" -L 1 bash -c '"$MAGICK" "$0[0]" "$1" && echo done' < "$WORK_LIST" | \
   while read -r _; do
     processed_count=$((${processed_count:-0} + 1))
 

--- a/scripts/update-tokens/save-new-tokens.sh
+++ b/scripts/update-tokens/save-new-tokens.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Prefer ImageMagick 7's `magick`, fall back to IM6's `convert`. Both
+# implement the same operators; this avoids IM7's deprecation warning.
+MAGICK=$(command -v magick 2>/dev/null || command -v convert)
+
 echo "Converting images to webp"
 
 # Create the destination folder if it doesn't exist
@@ -61,11 +65,11 @@ for image in ${images[@]}; do
     case $mimeType in
         image/svg+xml)
             rsvg-convert /tmp/$fileName -o /tmp/$fileName.png
-            magick /tmp/$fileName.png -resize 128x128 /tmp/${fileName}_resized.png
+            "$MAGICK" /tmp/$fileName.png -resize 128x128 /tmp/${fileName}_resized.png
             cwebp /tmp/${fileName}_resized.png -o "$destination" -quiet
             ;;
         image/png|image/jpeg)
-            magick /tmp/$fileName -resize 128x128 /tmp/${fileName}_resized.png
+            "$MAGICK" /tmp/$fileName -resize 128x128 /tmp/${fileName}_resized.png
             cwebp /tmp/${fileName}_resized.png -o "$destination" -quiet
             ;;
         image/gif)
@@ -79,14 +83,14 @@ for image in ${images[@]}; do
             ffmpeg -i /tmp/$fileName -vf "scale=128:128:force_original_aspect_ratio=decrease,fps=$fps_value" -loop 0 "$destination" -hide_banner -loglevel error
             ;;
         image/webp)
-            magick /tmp/$fileName -resize 128x128 /tmp/${fileName}_resized.webp
+            "$MAGICK" /tmp/$fileName -resize 128x128 /tmp/${fileName}_resized.webp
             mv /tmp/${fileName}_resized.webp "$destination"
             ;;
         image/avif)
             ffmpeg -i /tmp/$fileName -vf "scale=128:128" "$destination" -hide_banner -loglevel error
             ;;
         *)
-            magick /tmp/$fileName -resize 128x128 /tmp/${fileName}_resized.webp
+            "$MAGICK" /tmp/$fileName -resize 128x128 /tmp/${fileName}_resized.webp
             mv /tmp/${fileName}_resized.webp "$destination"
             ;;
     esac


### PR DESCRIPTION
## Summary

Fixes the two issues that surfaced on the first scheduled workflow run after merging #288.

## Root causes

1. **`magick: command not found`** — Ubuntu apt ships ImageMagick 6 which only provides `convert`. Scripts hardcoded `magick`, which exists only on IM7 (Homebrew on macOS). Every conversion in CI failed.
2. **Single bad input aborted the whole batch** — `xargs -P` with `&& echo done` under `set -euo pipefail` meant any worker failing (e.g. malformed webp, magick missing) propagated non-zero and killed the script before `colors.js` could run.

## Changes

### IM compat (`5d71c169`)
- Detect at runtime: `MAGICK=$(command -v magick 2>/dev/null || command -v convert)`
- Applied across `scripts/convert.sh`, `scripts/update-tokens/save-new-tokens.sh`, `scripts/update-tokens/convert-webp-to-png.sh`
- Prefers `magick` on IM7 (no deprecation warning), falls back to `convert` on IM6 (CI)

### Batch tolerance (`37c93cd6`)
- Each xargs worker now uses `... 2>/dev/null; echo done` instead of `... && echo done`
- A single failed conversion no longer aborts the entire script
- Missing PNGs are already handled downstream by `colors.js` falling back to default colors
- Added smoke test `08-corrupt-webp-tolerance.sh` that plants a malformed webp and verifies the batch keeps going

## Test plan

- [x] yarn test:smoke passes 8/8 locally
- [x] Verified test 08 catches the regression by temporarily reverting the fix
- [ ] After merging: trigger the scheduled workflow manually and confirm it completes the conversion + commit step