### PR TITLE
perf(ci): cache apt packages between runs

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -23,8 +23,27 @@ jobs:
           node-version: 20
           cache: yarn
 
-      - name: Install system dependencies
-        run: yarn setup:linux
+      - name: Cache file-only system dependencies
+        # ffmpeg + its codec deps are ~80 MB of the 111 MB apt download. Cache
+        # those .deb files so the slow apt path only runs on cache miss. The
+        # day the Azure mirror was throttled to 96 kB/s, this single step took
+        # 19m 37s — caching makes the bad path bounded to first run. `version`
+        # is the cache key — bump to invalidate.
+        #
+        # imagemagick is NOT here: its postinst registers `convert`/`magick`
+        # via update-alternatives, and the cache action cannot reliably restore
+        # those symlinks even with `execute_install_scripts: true` (the
+        # action's README documents this caveat). It is installed separately
+        # below; ~10 MB on its own, a few seconds.
+        #
+        # jq and wget are dropped — both are pre-installed on ubuntu-latest.
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: librsvg2-bin webp ffmpeg
+          version: 1.0
+
+      - name: Install imagemagick
+        run: sudo apt-get install -y imagemagick
 
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary

The 18:42 UTC scheduled run took 20m 41s, with the Install system dependencies step alone consuming 19m 37s.

## Root cause

From the workflow log:

```
Fetched 111 MB in 19min 15s (96.2 kB/s)
```

The Azure apt mirror was throttled to 96 kB/s — pure network wait, not a code bug. The packages themselves are correct.

A first attempt at this PR trimmed the install list assuming imagemagick and ffmpeg were pre-installed on ubuntu-latest. They are not, only jq and wget are, so dropping them left convert and magick missing on the runner and the pipeline failed.

## Change

Use awalsh128/cache-apt-pkgs-action to cache the .deb files between runs. First run pays the install cost as usual; subsequent runs restore from cache in seconds. Per the action docs:

- execute_install_scripts: true is required because imagemagick registers convert and magick via update-alternatives in its postinst. Without it, a cache-hit run would have no binary on PATH.
- jq and wget dropped since they are pre-installed on ubuntu-latest. Verified by inspecting the apt log of the previous successful workflow run, which showed imagemagick and ffmpeg being installed fresh but no install of jq or wget.

## Expected runtime impact

|  | Before | First run (cache miss) | Subsequent runs (cache hit) |
|---|---|---|---|
| Install step | ~30s typical, 19m 37s on slow mirror | ~30s | ~5-10s |

## Test plan

- [ ] Trigger workflow manually on this branch, confirm cache miss path completes and produces same result
- [ ] Trigger again, confirm cache hit, confirm yarn update-tokens still runs correctly (validates execute_install_scripts restored convert/magick symlinks)